### PR TITLE
Replaced legacy POSIX string functions by C89 equivalents

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,7 @@ include("cmake/ColorMessage.cmake")
 SET(BUILD_RTOSC_EXAMPLES FALSE CACHE BOOL
     "Build RTOSC Example Programs")
 
-if(CMAKE_SYSTEM_NAME MATCHES "Linux")
-    include(GNUInstallDirs)
-endif()
+include(GNUInstallDirs)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 if(NOT WIN32)
@@ -160,7 +158,7 @@ endif()
 
 
 #Installation
-if(CMAKE_SYSTEM_NAME MATCHES "Linux" AND NOT DEFINED RTOSC_NO_INSTALL)
+if(NOT DEFINED RTOSC_NO_INSTALL)
     if(PKG_CONFIG_FOUND)
         configure_file(librtosc.pc.cmake
             ${CMAKE_BINARY_DIR}/librtosc.pc @ONLY)


### PR DESCRIPTION
As of http://linux.die.net/man/3/index the index() and rindex() functions are legacy POSIX functions and shouldn't be used anymore. Instead use standard C89 string functions.

Fixed various other issues to allow successful cross compilation for Windows.