### PR TITLE
Msvc

### DIFF
--- a/include/rtosc/bundle-foreach.h
+++ b/include/rtosc/bundle-foreach.h
@@ -34,6 +34,7 @@
 #include <cctype>
 #include <cstdlib>
 #include <cstdio>
+#include "ports.h"
 
 namespace rtosc {
 

--- a/include/rtosc/miditable.h
+++ b/include/rtosc/miditable.h
@@ -95,7 +95,6 @@ struct MidiBijection
     float operator()(int x) const;
 };
 
-#include <cassert>
 class MidiMappernRT
 {
     public:

--- a/src/cpp/ports-runtime.cpp
+++ b/src/cpp/ports-runtime.cpp
@@ -41,7 +41,7 @@ class CapturePretty : public RtData
     void reply_va(const char *args, va_list va)
     {
         size_t nargs = strlen(args);
-        rtosc_arg_val_t arg_vals[nargs];
+        STACKALLOC(rtosc_arg_val_t, arg_vals, nargs);
 
         rtosc_v2argvals(arg_vals, nargs, args, va);
 

--- a/src/cpp/ports.cpp
+++ b/src/cpp/ports.cpp
@@ -1,4 +1,4 @@
-﻿#include "../util.h"
+#include "../util.h"
 #include "../../include/rtosc/ports.h"
 #include "../../include/rtosc/ports-runtime.h"
 #include "../../include/rtosc/bundle-foreach.h"
@@ -937,7 +937,7 @@ bool port_is_enabled(const Port* port, char* loc, size_t loc_size,
                 concatenate the location string
              */
             int loclen = strlen(loc);
-            char loc_copy[loc_size];
+            STACKALLOC(char, loc_copy, loc_size);
             strcpy(loc_copy, loc);
             if(subport)
                 strncat(loc_copy, "/../", loc_size - loclen - 1);
@@ -949,7 +949,7 @@ bool port_is_enabled(const Port* port, char* loc, size_t loc_size,
             /*
                 receive the "enabled" property
              */
-            char buf[loc_size];
+            STACKALLOC(char, buf, loc_size);
             // TODO: pass a parameter portname_from_base, since Ports might
             //       also be of type a#N/b
             const char* last_slash = strrchr(collapsed_loc, '/');
@@ -1230,8 +1230,8 @@ std::size_t rtosc::path_search(const Ports &root, const char *m,
     const char *needle = rtosc_argument(m,1).s;
     size_t max_args    = max_ports << 1;
     size_t max_types   = max_args + 1;
-    char types[max_types];
-    rtosc_arg_t args[max_args];
+    STACKALLOC(char, types, max_types);
+    STACKALLOC(rtosc_arg_t, args, max_args);
 
     path_search(root, str, needle, types, max_types, args, max_args);
     size_t length = rtosc_amessage(msgbuf, bufsize,

--- a/src/cpp/ports.cpp
+++ b/src/cpp/ports.cpp
@@ -316,7 +316,7 @@ int count_dups(std::vector<T> &t)
 {
     int dups = 0;
     int N = t.size();
-    bool mark[t.size()];
+    STACKALLOC(bool, mark, t.size());
     memset(mark, 0, N);
     for(int i=0; i<N; ++i) {
         if(mark[i])

--- a/src/cpp/ports.cpp
+++ b/src/cpp/ports.cpp
@@ -8,6 +8,7 @@
 #include <limits>
 #include <cstring>
 #include <string>
+#include <algorithm>
 
 /* Compatibility with non-clang compilers */
 #ifndef __has_feature

--- a/src/cpp/savefile.cpp
+++ b/src/cpp/savefile.cpp
@@ -326,7 +326,7 @@ int dispatch_printed_messages(const char* messages,
                 // nargs << 1 is usually too much, but it allows the user to use
                 // these values (using on_dispatch())
                 size_t maxargs = std::max(nargs << 1, 16);
-                rtosc_arg_val_t arg_vals[maxargs];
+                STACKALLOC(rtosc_arg_val_t, arg_vals, maxargs);
                 rd = rtosc_scan_message(msg_ptr, portname, buffersize,
                                         arg_vals, nargs, strbuf, buffersize);
                 rd_total += rd;
@@ -405,8 +405,8 @@ int dispatch_printed_messages(const char* messages,
                                     rtosc_arg_val_itr_next(&itr2);
                                 }
                             }
-                            rtosc_arg_t vals[val_max];
-                            char argstr[val_max+1];
+                            STACKALLOC(rtosc_arg_t, vals, val_max);
+                            STACKALLOC(char, argstr, val_max+1);
 
                             for(i = 0;
                                 itr.i - last_pos < (size_t)nargs &&

--- a/src/cpp/savefile.cpp
+++ b/src/cpp/savefile.cpp
@@ -17,17 +17,23 @@ namespace rtosc {
 std::string get_changed_values(const Ports& ports, void* runtime)
 {
     std::string res;
-    constexpr std::size_t buffersize = 8192;
+    //TODO: ugly hack but there are some disagreements about constexpr lambda captures
+    //see: https://stackoverflow.com/questions/44386415/gcc-and-clang-disagree-about-c17-constexpr-lambda-captures
+#define BUFFERSIZE_GET_CHANGED_VALUES 8192
+    constexpr std::size_t buffersize = BUFFERSIZE_GET_CHANGED_VALUES;
     char port_buffer[buffersize];
     memset(port_buffer, 0, buffersize); // requirement for walk_ports
-
-    const size_t max_arg_vals = 2048;
+#define MAX_ARG_VALS 2048
+    const size_t max_arg_vals = MAX_ARG_VALS;
 
     auto on_reach_port =
             [](const Port* p, const char* port_buffer,
                const char* port_from_base, const Ports& base,
                void* data, void* runtime)
     {
+        const size_t max_arg_vals = MAX_ARG_VALS;
+        constexpr std::size_t buffersize = BUFFERSIZE_GET_CHANGED_VALUES;
+
         assert(runtime);
         const Port::MetaContainer meta = p->meta();
 #if 0
@@ -174,6 +180,8 @@ std::string get_changed_values(const Ports& ports, void* runtime)
                                   rtosc_arg_val_t* arg_vals_runtime,
                                   int nargs_default, size_t nargs_runtime)
             {
+                constexpr std::size_t buffersize = BUFFERSIZE_GET_CHANGED_VALUES;
+
                 if(!rtosc_arg_vals_eq(arg_vals_default, arg_vals_runtime,
                                       nargs_default, nargs_runtime, nullptr))
                 {

--- a/src/cpp/savefile.cpp
+++ b/src/cpp/savefile.cpp
@@ -14,25 +14,22 @@
 
 namespace rtosc {
 
+namespace {
+    constexpr std::size_t buffersize = 8192;
+    constexpr size_t max_arg_vals = 2048;
+}
+
 std::string get_changed_values(const Ports& ports, void* runtime)
 {
     std::string res;
-    //TODO: ugly hack but there are some disagreements about constexpr lambda captures
-    //see: https://stackoverflow.com/questions/44386415/gcc-and-clang-disagree-about-c17-constexpr-lambda-captures
-#define BUFFERSIZE_GET_CHANGED_VALUES 8192
-    constexpr std::size_t buffersize = BUFFERSIZE_GET_CHANGED_VALUES;
     char port_buffer[buffersize];
     memset(port_buffer, 0, buffersize); // requirement for walk_ports
-#define MAX_ARG_VALS 2048
-    const size_t max_arg_vals = MAX_ARG_VALS;
 
     auto on_reach_port =
             [](const Port* p, const char* port_buffer,
                const char* port_from_base, const Ports& base,
                void* data, void* runtime)
     {
-        const size_t max_arg_vals = MAX_ARG_VALS;
-        constexpr std::size_t buffersize = BUFFERSIZE_GET_CHANGED_VALUES;
 
         assert(runtime);
         const Port::MetaContainer meta = p->meta();
@@ -180,8 +177,6 @@ std::string get_changed_values(const Ports& ports, void* runtime)
                                   rtosc_arg_val_t* arg_vals_runtime,
                                   int nargs_default, size_t nargs_runtime)
             {
-                constexpr std::size_t buffersize = BUFFERSIZE_GET_CHANGED_VALUES;
-
                 if(!rtosc_arg_vals_eq(arg_vals_default, arg_vals_runtime,
                                       nargs_default, nargs_runtime, nullptr))
                 {

--- a/src/cpp/savefile.cpp
+++ b/src/cpp/savefile.cpp
@@ -1,6 +1,7 @@
 #include <limits>
 #include <cassert>
 #include <cstring>
+#include <algorithm>
 
 #include "../util.h"
 #include <rtosc/arg-val-cmp.h>

--- a/src/dispatch.c
+++ b/src/dispatch.c
@@ -2,7 +2,9 @@
 #include <ctype.h>
 #include <assert.h>
 #include <string.h>
+#ifndef _MSC_VER
 #include <strings.h>
+#endif
 #include <stdlib.h>
 
 

--- a/src/pretty-format.c
+++ b/src/pretty-format.c
@@ -1,4 +1,4 @@
-﻿#include "util.h"
+#include "util.h"
 #include <assert.h>
 #include <inttypes.h>
 #include <limits.h>
@@ -563,7 +563,7 @@ size_t rtosc_print_arg_val(const rtosc_arg_val_t *arg,
         {
             char* last_sep = buffer - 1;
             int args_written_this_line = (cols_used) ? 1 : 0;
-            rtosc_arg_val_t args_converted[val->a.len]; // range conversion
+            STACKALLOC(rtosc_arg_val_t, args_converted, val->a.len); // range conversion
 
             COUNT_UP_WRITE('[');
             if(val->a.len)
@@ -633,7 +633,7 @@ size_t rtosc_print_arg_vals(const rtosc_arg_val_t *args, size_t n,
         opt = default_print_options;
     size_t sep_len = strlen(opt->sep);
     char* last_sep = buffer - 1;
-    rtosc_arg_val_t args_converted[n]; // only used for range conversion
+    STACKALLOC(rtosc_arg_val_t, args_converted, n); // only used for range conversion
 
     for(size_t i = 0; i < n;)
     {

--- a/src/rtosc.c
+++ b/src/rtosc.c
@@ -8,6 +8,7 @@
 
 #include <rtosc/rtosc.h>
 #include <rtosc/arg-val-math.h>
+#include "util.h"
 
 const char *rtosc_argument_string(const char *msg)
 {
@@ -377,7 +378,7 @@ size_t rtosc_vmessage(char   *buffer,
     if(!nargs)
         return rtosc_amessage(buffer,len,address,arguments,NULL);
 
-    rtosc_arg_t args[nargs];
+    STACKALLOC(rtosc_arg_t, args, nargs);
     rtosc_va_list_t ap2;
     va_copy(ap2.a, ap);
     rtosc_v2args(args, nargs, arguments, &ap2);
@@ -403,8 +404,8 @@ size_t rtosc_avmessage(char                  *buffer,
             rtosc_arg_val_itr_next(&itr2);
     }
 
-    rtosc_arg_t vals[val_max];
-    char argstr[val_max+1];
+    STACKALLOC(rtosc_arg_t, vals, val_max);
+    STACKALLOC(char, argstr,val_max+1);
 
     int i;
     for(i = 0; i < val_max; ++i)

--- a/src/util.h
+++ b/src/util.h
@@ -51,6 +51,12 @@ extern "C" {
  */
 char *fast_strcpy(char *dest, const char *src, size_t buffersize);
 
+/*TODO: Add documentation?*/
+#ifdef _MSC_VER
+#define STACKALLOC(type, name, size) type *name = (type*)(_alloca((size)*sizeof(type)))
+#else
+#define STACKALLOC(type, name, size) type name[size]
+#endif
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
I've made some changes to be able to compile this with msvc.

The most important change is I defined STACKALLOC to deal with the VLAs that are missing in msvc. It produces the same code when compiled on gcc, clang but changes to _alloca call which also allocates memory on the stack when using msvc.

Another thing is the lambda capture of a constexpr. To be honest, I have no idea how to deal with that properly. I made a quick hack of it, but maybe someone with more experience with the c++ standard can shed some light on this. I've found this ref: https://stackoverflow.com/questions/44386415/gcc-and-clang-disagree-about-c17-constexpr-lambda-captures, it talks about the different interpretations between clang & gcc. Then again, I could be totally wrong in my interpretation of the error.
