### PR TITLE
Fix rtosc_bundle_size function and add test for it

### DIFF
--- a/src/rtosc.c
+++ b/src/rtosc.c
@@ -895,7 +895,7 @@ size_t rtosc_bundle_size(const char *buffer, unsigned elm)
     const uint32_t *lengths = (const uint32_t*) (buffer+16);
     size_t elm_pos = 0;
     size_t last_len = 0;
-    while(elm_pos!=elm && extract_uint32((const uint8_t*)lengths)) {
+    while(elm_pos!=elm+1 && extract_uint32((const uint8_t*)lengths)) {
         last_len = extract_uint32((const uint8_t*)lengths);
         ++elm_pos, lengths+=extract_uint32((const uint8_t*)lengths)/4+1;
     }

--- a/test/bundles.c
+++ b/test/bundles.c
@@ -56,6 +56,13 @@ int main()
     assert_str_eq("/foobar-message", rtosc_bundle_fetch(buffer_c, 1),
             "Verifying Message 2 Path", __LINE__);
 
+    //Verify that rtosc_bundle_size works
+    assert_int_eq(0x1c, rtosc_bundle_size(buffer_c, 0),
+            "Verify rtosc_bundle_size() Works", __LINE__);
+
+    assert_int_eq(0x18, rtosc_bundle_size(buffer_c, 1),
+            "Verify rtosc_bundle_size() Works", __LINE__);
+
     //Check minimum bundle size #bundle + time tag
     assert_int_eq(8+8, rtosc_bundle(buffer_c, 256, 1, 0),
             "Verify Minimum Legal Bundle Size", __LINE__);


### PR DESCRIPTION
The rtosc_bundle_size function had a off-by-one problem. I realized
because I was using the function, and had to add 1 to the index
parameter to get proper results.
This commit fixes it and adds tests to prove it and detect issues in the
future.