### PR TITLE
Port::apropos(): fix for `Port::name` == '/a/b/c'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,7 @@ endif()
 
 maketestcpp(test-midi-mapper)
 maketestcpp(metadata)
+maketestcpp(apropos)
 maketestcpp(default-value)
 maketestcpp(headerlib)
 maketestcpp(test-walker)

--- a/src/cpp/ports.cpp
+++ b/src/cpp/ports.cpp
@@ -745,21 +745,16 @@ const Port *Ports::operator[](const char *name) const
     return NULL;
 }
 
-static msg_t snip(msg_t m)
-{
-    while(*m && *m != '/') ++m;
-    return m+1;
-}
-
 const Port *Ports::apropos(const char *path) const
 {
     if(path && path[0] == '/')
         ++path;
 
+    const char* path_end;
     for(const Port &port: ports)
-        if(strchr(port.name,'/') && rtosc_match_path(port.name,path, NULL))
+        if(strchr(port.name,'/') && rtosc_match_path(port.name,path, &path_end))
             return (strchr(path,'/')[1]==0) ? &port :
-                port.ports->apropos(snip(path));
+                port.ports->apropos(path_end);
 
     //This is the lowest level, now find the best port
     for(const Port &port: ports)

--- a/test/common.h
+++ b/test/common.h
@@ -33,6 +33,19 @@ int assert_char_eq(char a, char b, const char *testcase, int line)
     return err;
 }
 
+int assert_ptr_eq(const void* a, const void* b, const char *testcase, int line)
+{
+    test_counter++;
+    int err = a!=b;
+    if(err) {
+        printf("not ok %d - %s...\n", test_counter, testcase);
+        printf("# Expected %p, but observed %p instead (line %d)\n", a, b, line);
+        global_err++;
+    } else
+        printf("ok %d - %s...\n", test_counter, testcase);
+    return err;
+}
+
 int assert_true(int a, const char *testcase, int line)
 {
     test_counter++;


### PR DESCRIPTION
Only CI checking...