### PR TITLE
automations: fix gcc compiler warning

### DIFF
--- a/src/cpp/automations.cpp
+++ b/src/cpp/automations.cpp
@@ -245,7 +245,7 @@ void AutomationMgr::setSlotSubPath(int slot, int ind, const char *path)
     if(slot >= nslots || slot < 0)
         return;
 
-	assert(p);
+    assert(p);
     const Port *port = p->apropos(path);
     if(!port) {
         fprintf(stderr, "[Zyn:Error] port '%s' does not exist\n", path);
@@ -291,8 +291,7 @@ void AutomationMgr::setSlotSubPath(int slot, int ind, const char *path)
         au.map.control_scale = 0;
 
     updateMapping(slot, ind);
-	damaged = true;
-
+    damaged = true;
 }
 
 void  AutomationMgr::setSlotSubGain(int slot_id, int sub, float f)


### PR DESCRIPTION
The file is indented with 4 spaces. Some lines are incorrectly indented with
TABs. This commit change those TABs to 4 spaces to fix the gcc misleading
indentation warning.

Fixes:

    src/cpp/automations.cpp: In member function ‘void rtosc::AutomationMgr::setSlotSubPath(int, int, const char*)’:
    src/cpp/automations.cpp:245:5: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
      245 |     if(slot >= nslots || slot < 0)
          |     ^~
    In file included from /usr/include/c++/11/cassert:44,
                     from include/rtosc/automations.h:3,
                     from src/cpp/automations.cpp:2:
    src/cpp/automations.cpp:248:9: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
      248 |         assert(p);
          |         ^~~~~~

Note: this warning is reported by gcc 11.2.1, on Fedora 35.

Signed-off-by: Julien Olivain <ju.o@free.fr>