### PR TITLE
Fix ThreadLink overwriting messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,7 @@ if(JACK_FOUND)
     include_directories(${JACK_INCLUDE_DIRS})
 endif()
 
+maketestcpp(thread-link-test)
 maketestcpp(test-midi-mapper)
 maketestcpp(metadata)
 maketestcpp(apropos)

--- a/src/cpp/thread-link.cpp
+++ b/src/cpp/thread-link.cpp
@@ -41,7 +41,7 @@ static void ring_write(ringbuffer_t *ring, const char *data, size_t len)
 
     //discontinuous write
     if(next_write < ring->write) {
-        const size_t w1 = ring->size - ring->write - 1;
+        const size_t w1 = ring->size - ring->write;
         const size_t w2 = len - w1;
         memcpy(ring->buffer+ring->write, data,    w1);
         memcpy(ring->buffer,             data+w1, w2);
@@ -57,10 +57,10 @@ static void ring_read(ringbuffer_t *ring, char *data, size_t len)
 
     //discontinuous read
     if(next_read < ring->read) {
-        const size_t r1 = ring->size - ring->read - 1;
+        const size_t r1 = ring->size - ring->read;
         const size_t r2 = len - r1;
         memcpy(data,    ring->buffer+ring->read, r1);
-        memcpy(data+r1, ring->buffer,             r2);
+        memcpy(data+r1, ring->buffer,            r2);
     } else { //contiguous
         memcpy(data, ring->buffer+ring->read, len);
     }
@@ -73,7 +73,7 @@ static void ring_read_vector(ringbuffer_t *ring, ring_t *r)
     off_t  read      = ring->read;
     r[0].data = ring->buffer+ring->read;
     if(read_size+read > ring->size) { //discontinuous
-        size_t r2 = (read_size+1+read)%ring->size;
+        size_t r2 = (read_size+read)%ring->size;
         size_t r1 = read_size - r2;
         r[0].len  = r1;
         r[1].data = ring->buffer;

--- a/test/thread-link-test.cpp
+++ b/test/thread-link-test.cpp
@@ -1,0 +1,38 @@
+#include "common.h"
+
+#include <rtosc/thread-link.h>
+
+int main()
+{
+    // max 4 messages of each 32 -> 128 bytes size
+    rtosc::ThreadLink thread_link(32,4);
+    char portname[] = "abcdefghijklmnop"; // length 16, array size 17
+    rtosc::msg_t read_msg;
+
+    // always write one message ahead, to check that a second message
+    // does not corrupt the "message under test"
+    thread_link.write(portname, "i", 42);
+
+    // 10 rounds are enough to have 1 discontigous write
+    for (int round = 0; round < 10; ++round)
+    {
+        // write 17 bytes + 3 bytes padding + 4 bytes argstr + 4 bytes args = 28 bytes
+        thread_link.write(portname, "i", 42);
+        read_msg = thread_link.read();
+
+        char test_name [] = "round 0 string equals";
+        test_name[6] += round % 10;
+        assert_str_eq(portname, read_msg, test_name, __LINE__);
+
+        const char* arg_str = rtosc_argument_string(read_msg);
+        assert_str_eq("i", arg_str, "arg string correct", __LINE__);
+        if(!strcmp(arg_str, "i"))
+            assert_int_eq(42, rtosc_argument(read_msg, 0).i, "arg 1 correct", __LINE__);
+        else {
+            // invalid state, don't crash the test
+        }
+    }
+
+    return test_summary();
+}
+


### PR DESCRIPTION
This fixes an issue where a write to ThreadLink after a contigous write
would corrupt the last byte of the previous message.

Before the patch, when ThreadLink would want to split the buffer into 2
halves, the sizes were computed as

```
const size_t w1 = ring->size - ring->write - 1
const size_t w2 = len - w1
```

This was wasting one (usable) byte - the last byte of `ring->buffer`.
However, the real problem with this was that the subsequent write
position was *not* wasting this byte:

```
const off_t  next_write = (ring->write + len)%ring->size
```

So these 2 variables did not fit each other, and the next write position
was calculated one byte too low.

The bugfix is to simply turn off the behavior of wasting the last byte
of `ring->buffer` in `ring_write`. The read functions are patched
accordingly.

A test has been added that fails without this patch.