### PR TITLE
Read lookahead

### DIFF
--- a/include/rtosc/thread-link.h
+++ b/include/rtosc/thread-link.h
@@ -65,12 +65,33 @@ class ThreadLink
         /**
          * @returns true iff there is another message to be read in the buffer
          */
+        bool hasNext(bool lookahead) const;
+
+        /**
+         * @returns true iff there is another message to be read in the buffer
+         */
         bool hasNext(void) const;
+
+        /**
+         * @returns true iff there is another message to be read in the buffer
+         */
+        bool hasNextLookahead(void) const;
+
+        /**
+         * Read a new message from the ringbuffer, optionally from lookahead
+         * queue
+         */
+        msg_t read(bool lookahead);
 
         /**
          * Read a new message from the ringbuffer
          */
         msg_t read(void);
+
+        /**
+         * Read a new message from the ringbuffer along the lookahead queue
+         */
+        msg_t read_lookahead(void);
 
         /**
          * Peak at last message read without reading another

--- a/src/cpp/thread-link.cpp
+++ b/src/cpp/thread-link.cpp
@@ -13,15 +13,20 @@ struct internal_ringbuffer_t {
     char *buffer;
     std::atomic<off_t> write;
     std::atomic<off_t> read;
+    /* read_lookahead strictly speaking does not need to be atomic as it is
+     * only accessed from the read side, but it makes things easier if it's
+     * the same type as read.
+     */
+    std::atomic<off_t> read_lookahead;
     size_t size;
 };
 
 typedef internal_ringbuffer_t ringbuffer_t;
 
-static size_t ring_read_size(ringbuffer_t *ring)
+static size_t ring_read_size(ringbuffer_t *ring, bool lookahead)
 {
     const size_t w = ring->write;
-    const size_t r = ring->read;
+    const size_t r = lookahead ? ring->read_lookahead : ring->read;
 
     return (w-r+ring->size) % ring->size;
 }
@@ -50,28 +55,37 @@ static void ring_write(ringbuffer_t *ring, const char *data, size_t len)
     }
     ring->write = next_write;
 }
-static void ring_read(ringbuffer_t *ring, char *data, size_t len)
+static void ring_read(ringbuffer_t *ring, char *data, size_t len, bool lookahead)
 {
-    assert(ring_read_size(ring) >= len);
-    const off_t  next_read = (ring->read + len)%ring->size;
+    assert(ring_read_size(ring, lookahead) >= len);
+    const off_t  read = lookahead ? ring->read_lookahead : ring->read;
+    const off_t  next_read = (read + len)%ring->size;
 
     //discontinuous read
-    if(next_read < ring->read) {
-        const size_t r1 = ring->size - ring->read;
+    if(next_read < read) {
+        const size_t r1 = ring->size - read;
         const size_t r2 = len - r1;
-        memcpy(data,    ring->buffer+ring->read, r1);
-        memcpy(data+r1, ring->buffer,            r2);
+        memcpy(data,    ring->buffer+read, r1);
+        memcpy(data+r1, ring->buffer,      r2);
     } else { //contiguous
-        memcpy(data, ring->buffer+ring->read, len);
+        memcpy(data, ring->buffer+read, len);
     }
-    ring->read = next_read;
+    if (lookahead)
+        ring->read_lookahead = next_read;
+    else
+        /* When doing an ordinary read, synchronize lookahead pointer with
+         * read pointer, so that subsequent lookahead reads will start from
+         * the read pointer. This way, we guarantee that the lookahead
+         * queue is always equal to or shorter than the read queue.
+         */
+        ring->read_lookahead = ring->read = next_read;
 }
-static void ring_read_vector(ringbuffer_t *ring, ring_t *r)
+static void ring_read_vector(ringbuffer_t *ring, ring_t *r, bool lookahead)
 {
     assert(r);
-    size_t read_size = ring_read_size(ring);
-    off_t  read      = ring->read;
-    r[0].data = ring->buffer+ring->read;
+    size_t read_size = ring_read_size(ring, lookahead);
+    off_t  read      = lookahead ? ring->read_lookahead : ring->read;
+    r[0].data = ring->buffer+read;
     if(read_size+read > ring->size) { //discontinuous
         size_t r2 = (read_size+read)%ring->size;
         size_t r1 = read_size - r2;
@@ -92,10 +106,11 @@ ThreadLink::ThreadLink(size_t max_message_length, size_t max_messages)
     read_buffer(new char[MaxMsg]),
     ring(new ringbuffer_t)
 {
-    ring->buffer = new char[BufferSize];
-    ring->size   = BufferSize;
-    ring->read   = 0;
-    ring->write  = 0;
+    ring->buffer         = new char[BufferSize];
+    ring->size           = BufferSize;
+    ring->read           = 0;
+    ring->read_lookahead = 0;
+    ring->write          = 0;
     memset(write_buffer, 0, MaxMsg);
     memset(read_buffer, 0, MaxMsg);
 }
@@ -140,23 +155,54 @@ void ThreadLink::raw_write(const char *msg)
 /**
  * @returns true iff there is another message to be read in the buffer
  */
+bool ThreadLink::hasNext(bool lookahead) const
+{
+    return ring_read_size(ring, lookahead);
+}
+
+/**
+ * @returns true iff there is another message to be read in the buffer
+ */
 bool ThreadLink::hasNext(void) const
 {
-    return ring_read_size(ring);
+    return ThreadLink::hasNext(false);
+}
+
+/**
+ * @returns true iff there is another message to be read in the lookahead queue
+ */
+bool ThreadLink::hasNextLookahead(void) const
+{
+    return ThreadLink::hasNext(true);
+}
+
+/**
+ * Read a new message from the ringbuffer
+ * @lookahead: normally False, set to True when reading from the lookahead queue
+ */
+msg_t ThreadLink::read(bool lookahead) {
+    ring_t r[2];
+    ring_read_vector(ring,r,lookahead);
+    const size_t len =
+        rtosc_message_ring_length(r);
+    assert(ring_read_size(ring, lookahead) >= len);
+    assert(len <= MaxMsg);
+    ring_read(ring, read_buffer, len, lookahead);
+    return read_buffer;
 }
 
 /**
  * Read a new message from the ringbuffer
  */
 msg_t ThreadLink::read(void) {
-    ring_t r[2];
-    ring_read_vector(ring,r);
-    const size_t len =
-        rtosc_message_ring_length(r);
-    assert(ring_read_size(ring) >= len);
-    assert(len <= MaxMsg);
-    ring_read(ring, read_buffer, len);
-    return read_buffer;
+    return ThreadLink::read(false);
+}
+
+/**
+ * Read a new message from the ringbuffer along the lookahead queue
+ */
+msg_t ThreadLink::read_lookahead(void) {
+    return ThreadLink::read(true);
 }
 
 /**

--- a/test/thread-link-test.cpp
+++ b/test/thread-link-test.cpp
@@ -38,9 +38,105 @@ void test_contiguous_write()
     }
 }
 
+void test_read_lookahead()
+{
+    // max 4 messages of each 32 -> 128 bytes size
+    rtosc::ThreadLink thread_link(32,4);
+    char portname[] = "abcdefghijklmnop"; // length 16, array size 17
+    rtosc::msg_t read_msg;
+
+    // write five messages, causing the buffer to wrap around, thus testing
+    // that the lookahead read works under this circumstance as well
+    // message length:
+    // 17 bytes + 3 bytes padding + 4 bytes argstr + 4 bytes args = 28 bytes
+    // first message is not actually used in test, it's just there to
+    // cause the buffer to wrap around.
+    thread_link.write(portname, "i", 41);
+    // we can still verify that it reads back properly
+    assert_true(thread_link.hasNext(), "Initial message has next", __LINE__);
+    read_msg = thread_link.read();
+    verify_msg(read_msg, portname, 41, "Initial message read", __LINE__);
+    assert_false(thread_link.hasNext(), "Initial message empty queue", __LINE__);
+
+    // Now for the writes that we are going to use for the tests
+    thread_link.write(portname, "i", 42);
+    thread_link.write(portname, "i", 43);
+    thread_link.write(portname, "i", 44);
+    thread_link.write(portname, "i", 45);
+
+    // Verify there is something in buffer, then read lookahead queue
+    // until nothing left to read
+    assert_true(thread_link.hasNext(), "1: Has next", __LINE__);
+
+    assert_true(thread_link.hasNextLookahead(), "1: Has next lookahead [1]", __LINE__);
+    read_msg = thread_link.read_lookahead();
+    verify_msg(read_msg, portname, 42, "1: Lookahead [1]", __LINE__);
+
+    assert_true(thread_link.hasNextLookahead(), "1: Has next lookahead [2]", __LINE__);
+    read_msg = thread_link.read_lookahead();
+    verify_msg(read_msg, portname, 43, "1: Lookahead [2]", __LINE__);
+
+    assert_true(thread_link.hasNextLookahead(), "1: Has next lookahead [3]", __LINE__);
+    read_msg = thread_link.read_lookahead();
+    verify_msg(read_msg, portname, 44, "1: Lookahead [3]", __LINE__);
+
+    assert_true(thread_link.hasNextLookahead(), "1: Has next lookahead [4]", __LINE__);
+    read_msg = thread_link.read_lookahead();
+    verify_msg(read_msg, portname, 45, "1: Lookahead [4]", __LINE__);
+
+    assert_false(thread_link.hasNextLookahead(), "1: Has no lookahead next", __LINE__);
+
+    // Actually read first message, verify it, then read lookahead queue
+    // until nothing left to read.
+    assert_true(thread_link.hasNext(), "2: Has next", __LINE__);
+    read_msg = thread_link.read();
+    verify_msg(read_msg, portname, 42, "2: Read [1]", __LINE__);
+
+    assert_true(thread_link.hasNextLookahead(), "2: Has next lookahead [1]", __LINE__);
+    read_msg = thread_link.read_lookahead();
+    verify_msg(read_msg, portname, 43, "2: Lookahead [2]", __LINE__);
+
+    assert_true(thread_link.hasNextLookahead(), "2: Has next lookahead [2]", __LINE__);
+    read_msg = thread_link.read_lookahead();
+    verify_msg(read_msg, portname, 44, "2: Lookahead [3]", __LINE__);
+
+    assert_true(thread_link.hasNextLookahead(), "2: Has next lookahead [3]", __LINE__);
+    read_msg = thread_link.read_lookahead();
+    verify_msg(read_msg, portname, 45, "2: Lookahead [4]", __LINE__);
+
+    assert_false(thread_link.hasNextLookahead(), "2: Has no lookahead next", __LINE__);
+
+    // Read two messages, verify them, then read lookahead queue
+    // until nothing left to read.
+    assert_true(thread_link.hasNext(), "3: Has next", __LINE__);
+    read_msg = thread_link.read();
+    verify_msg(read_msg, portname, 43, "3: Read [1]", __LINE__);
+
+    assert_true(thread_link.hasNext(), "3: Has next", __LINE__);
+    read_msg = thread_link.read();
+    verify_msg(read_msg, portname, 44, "3: Read [1]", __LINE__);
+
+    assert_true(thread_link.hasNextLookahead(), "3: Has next lookahead [1]", __LINE__);
+    read_msg = thread_link.read_lookahead();
+    verify_msg(read_msg, portname, 45, "3: Lookahead [1]", __LINE__);
+
+    assert_false(thread_link.hasNextLookahead(), "3: Has no lookahead next", __LINE__);
+
+    // Read final message, verify it, then verify lookahead queue is empty,
+    // and read queue as well.
+    assert_true(thread_link.hasNext(), "4: Has next", __LINE__);
+    read_msg = thread_link.read();
+    verify_msg(read_msg, portname, 45, "4: Read [1]", __LINE__);
+
+    assert_false(thread_link.hasNextLookahead(), "4: Has no lookahead next", __LINE__);
+
+    assert_false(thread_link.hasNext(), "4: Has no next", __LINE__);
+}
+
 int main()
 {
     test_contiguous_write();
+    test_read_lookahead();
 
     return test_summary();
 }

--- a/test/thread-link-test.cpp
+++ b/test/thread-link-test.cpp
@@ -29,12 +29,12 @@ void test_contiguous_write()
     for (int round = 0; round < 10; ++round)
     {
         // write 17 bytes + 3 bytes padding + 4 bytes argstr + 4 bytes args = 28 bytes
-        thread_link.write(portname, "i", 42);
+        thread_link.write(portname, "i", 43 + round);
         read_msg = thread_link.read();
 
         char test_name [] = "round 0";
         test_name[6] += round % 10;
-        verify_msg(read_msg, portname, 42, test_name, __LINE__);
+        verify_msg(read_msg, portname, 42 + round, test_name, __LINE__);
     }
 }
 

--- a/test/thread-link-test.cpp
+++ b/test/thread-link-test.cpp
@@ -1,6 +1,18 @@
 #include "common.h"
+#include <string>
 
 #include <rtosc/thread-link.h>
+
+void verify_msg(rtosc::msg_t read_msg, const char *portname, int value, const char *test_id, int line)
+{
+    const std::string test_string = test_id;
+
+    assert_str_eq(portname, read_msg, (test_string + " (portname)").c_str(), line);
+    const char* arg_str = rtosc_argument_string(read_msg);
+    assert_str_eq("i", arg_str, (test_string + " (arg type)").c_str(), line);
+    if(!strcmp(arg_str, "i"))
+        assert_int_eq(value, rtosc_argument(read_msg, 0).i, (test_string + " (arg value)").c_str(), line);
+}
 
 void test_contiguous_write()
 {
@@ -20,17 +32,9 @@ void test_contiguous_write()
         thread_link.write(portname, "i", 42);
         read_msg = thread_link.read();
 
-        char test_name [] = "round 0 string equals";
+        char test_name [] = "round 0";
         test_name[6] += round % 10;
-        assert_str_eq(portname, read_msg, test_name, __LINE__);
-
-        const char* arg_str = rtosc_argument_string(read_msg);
-        assert_str_eq("i", arg_str, "arg string correct", __LINE__);
-        if(!strcmp(arg_str, "i"))
-            assert_int_eq(42, rtosc_argument(read_msg, 0).i, "arg 1 correct", __LINE__);
-        else {
-            // invalid state, don't crash the test
-        }
+        verify_msg(read_msg, portname, 42, test_name, __LINE__);
     }
 }
 

--- a/test/thread-link-test.cpp
+++ b/test/thread-link-test.cpp
@@ -2,7 +2,7 @@
 
 #include <rtosc/thread-link.h>
 
-int main()
+void test_contiguous_write()
 {
     // max 4 messages of each 32 -> 128 bytes size
     rtosc::ThreadLink thread_link(32,4);
@@ -32,6 +32,11 @@ int main()
             // invalid state, don't crash the test
         }
     }
+}
+
+int main()
+{
+    test_contiguous_write();
 
     return test_summary();
 }


### PR DESCRIPTION
This PR adds a read lookahead functionality to ThreadLink, so that messages can be read from the read side without actually removing them from the buffer (until a subsequent read does this as usual). This is intended to support a cleaner way to implement the fix in https://github.com/zynaddsubfx/zynaddsubfx/pull/195 so that it's not necessary to pull out the messages up until /state_frozen and then reinsert them into the ring buffer later.

This PR in itself does not change any behaviour in ThreadLink unless the new lookahead read functionality is actually used by the client; my plan is to submit a new PR for zynaddsubfx which uses the new read lookahead functionality once this PR has been approved.

The PR includes a test for the lookahead read operation to validate that it doesn't affect the normal read operation.