### PR TITLE
Fix invalid comparison operator in .pc files

### DIFF
--- a/librtosc-cpp.pc.cmake
+++ b/librtosc-cpp.pc.cmake
@@ -9,6 +9,6 @@ includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 Name: rtosc_cpp
 Description: rtosc_cpp - a realtime safe open sound control serialization and dispatch system for C++
 Version: @VERSION_MAJOR@.@VERSION_MINOR@.@VERSION_PATCH@
-Requires: librtosc == @VERSION_MAJOR@.@VERSION_MINOR@.@VERSION_PATCH@
+Requires: librtosc = @VERSION_MAJOR@.@VERSION_MINOR@.@VERSION_PATCH@
 Libs: -L${libdir} -lrtosc -lrtosc-cpp
 Cflags: -I${includedir}


### PR DESCRIPTION
Fixes issue when running pkg-config:

```sh
$ pkg-config --libs librtosc-cpp 
Unknown version comparison operator '==' after package name 'librtosc' in file '/usr/lib64/pkgconfig/librtosc-cpp.pc'
```