### PR TITLE
Implement rLogWithLogmin

### DIFF
--- a/example/complex/Fl_Osc_Widget.H
+++ b/example/complex/Fl_Osc_Widget.H
@@ -46,7 +46,7 @@ class Fl_Osc_Widget
             if(!strcmp(scale,"linear"))
                 return x*(max-min)+min;
             else if(!strcmp(scale,"logarithmic")) {
-                const float b = log(min);
+                const float b = log(meta["logmin"] ? atof(meta["logmin"]) : min);
                 const float a = log(max)-b;
                 return expf(a*x+b);
             }
@@ -66,7 +66,7 @@ class Fl_Osc_Widget
             if(!strcmp(scale, "linear"))
                 return (x-min)/(max-min);
             else if(!strcmp(scale, "logarithmic")) {
-                const float b = log(min);
+                const float b = log(meta["logmin"] ? atof(meta["logmin"]) : min);
                 const float a = log(max)-b;
                 return (log(x)-b)/a;
             }

--- a/include/rtosc/port-sugar.h
+++ b/include/rtosc/port-sugar.h
@@ -336,6 +336,8 @@ template<class T> constexpr T spice(T*t) {return *t;}
 //has no special meaning, rLinear shall be used.
 #define rLinear(min_, max_) rMap(min, min_) rMap(max, max_) rMap(scale, linear)
 #define rLog(min_, max_) rMap(min, min_) rMap(max, max_) rMap(scale, logarithmic)
+// rLogWithLogmin: "logmin" is the minimum value of the domain of the logarithm
+#define rLogWithLogmin(min_, max_, logmin_) rMap(min, min_) rMap(max, max_) rMap(logmin, logmin_) rMap(scale, logarithmic)
 
 //Special values
 #define rSpecial(doc) ":special\0" STRINGIFY(doc) "\0"

--- a/src/cpp/automations.cpp
+++ b/src/cpp/automations.cpp
@@ -92,7 +92,7 @@ void AutomationMgr::createBinding(int slot, const char *path, bool start_midi_le
 
     if(meta["scale"] && strstr(meta["scale"], "log")) {
         au.map.control_scale = 1;
-        au.param_min = logf(au.param_min);
+        au.param_min = meta["logmin"] ? logf(atof(meta["logmin"])) : au.param_min;
         au.param_max = logf(au.param_max);
     } else
         au.map.control_scale = 0;
@@ -285,7 +285,7 @@ void AutomationMgr::setSlotSubPath(int slot, int ind, const char *path)
 
     if(meta["scale"] && strstr(meta["scale"], "log")) {
         au.map.control_scale = 1;
-        au.param_min = logf(au.param_min);
+        au.param_min = logf(meta["logmin"] ? atof(meta["logmin"]) : au.param_min);
         au.param_max = logf(au.param_max);
     } else
         au.map.control_scale = 0;

--- a/src/cpp/miditable.cpp
+++ b/src/cpp/miditable.cpp
@@ -259,7 +259,7 @@ float MidiTable::translate(uint8_t val, const char *meta_)
     if(!strcmp(scale,"linear"))
         return x*(max-min)+min;
     else if(!strcmp(scale,"logarithmic")) {
-        const float b = log(min);
+        const float b = log(meta["logmin"] ? atof(meta["logmin"]) : min);
         const float a = log(max)-b;
         return expf(a*x+b);
     }


### PR DESCRIPTION
This implements a version of `rLog`, where the minimum of the domain of the logarithm is different to the minimum settable value (this can be if the minimum value means "off").

This PR also replaces all uses of "min" by the use of "logmin" whenever appropriate.