### PR TITLE
Fix various typos

### DIFF
--- a/cmake/ColorMessage.cmake
+++ b/cmake/ColorMessage.cmake
@@ -1,5 +1,5 @@
 #Very non-portable workaround to detect if the current cmake process is
-#outputing to a valid looking terminal (on LINUX only)
+#outputting to a valid looking terminal (on LINUX only)
 if(EXISTS /proc/self/fd/1)
     get_filename_component(STDOUT /proc/self/fd/1 REALPATH)
 else()

--- a/doc/Guide.adoc
+++ b/doc/Guide.adoc
@@ -382,7 +382,7 @@ inf
 -----
 * For accepting numeric literals, rtosc first calculates the end of the
   literal by searching for an end of the string, a space character or a
-  closing paranthesis (')'). Then, it behaves like trying out a number of
+  closing parenthesis (')'). Then, it behaves like trying out a number of
   scanf format strings in the order shown below.
   The first format string that matched exactly from the beginning to the
   previously calculated end is being used for scanning, and the corresponding
@@ -390,7 +390,7 @@ inf
   be identical to the behaviour of a C99 parser. For the exact meanings of the
   format strings, consider your fscanf(3p) man page.
   One extension to C99 is that the user can specify the exact value of a float
-  or double inside parantheses using the hex notation.
+  or double inside parentheses using the hex notation.
 ---------------
 "%*"PRIi32"i%n"  % assume 'i' (4 byte int)
 "%*"PRIi64"h%n"  % assume 'h' (8 byte int)
@@ -414,7 +414,7 @@ inf
 0xfp+0                % 'f' (if you wanted the above to be a float, =15.0f)
 0x1f                  % 'i' (no float!, value is 31)
 1f                    % 'f' (1.0f)
-0.000061 (0x0.1p-10)  % 'f' (the exact value is inside of parantheses)
+0.000061 (0x0.1p-10)  % 'f' (the exact value is inside of parentheses)
 -------------
 * ANSII strings and characters are also used like in C99, which includes
 escape sequences. Strings can also be concatenated by appending a backslash
@@ -430,7 +430,7 @@ after the first string's ending quote.
 ----------
 MIDI [0xff 0xff 0xff 0xff]
 ----------
-* Blobs are being printed as an integer "n" folled by "n" hex numbers:
+* Blobs are being printed as an integer "n" followed by "n" hex numbers:
 ----------
 [6 0x72 0x74 0x6f 0x73 0x63 0x00]
 [0]
@@ -514,7 +514,7 @@ Default Values
 ~~~~~~~~~~~~~~
 
 Default values usually describe what an app can answer best if it currently has
-no valid data, or if it is in an initial or resetted state. The datatypes and
+no valid data, or if it is in an initial or reset state. The datatypes and
 the values which the ports reply as such a default response should be passed to
 the rDefault macro family in the <<Pretty-printing Messages, "pretty format">>.
 

--- a/include/rtosc/automations.h
+++ b/include/rtosc/automations.h
@@ -37,7 +37,7 @@ struct Automation
     //relative or absolute
     bool relative;
 
-    //Cached infomation
+    //Cached information
     float       param_base_value;
     char        param_path[128];
     char        param_type;

--- a/include/rtosc/default-value.h
+++ b/include/rtosc/default-value.h
@@ -73,7 +73,7 @@ const char* get_default_value(const char* port_name, const struct Ports& ports,
  * @param res The output parameter for the argument values.
  * @param strbuf String buffer for storing pretty printed strings and blobs.
  * @param strbufsize Size of @p strbuf
- * @return The actual number of aruments written to @p res (can be smaller
+ * @return The actual number of arguments written to @p res (can be smaller
  *         than @p n) or -1 if there is no valid default annotation
  */
 int get_default_value(const char* port_name, const char *port_args,

--- a/include/rtosc/miditable.h
+++ b/include/rtosc/miditable.h
@@ -160,7 +160,7 @@ class MidiMapperRT
         void addWatch(void);
         void remWatch(void);
 
-        //Depricated
+        //Deprecated
         Port addWatchPort(void);
         Port removeWatchPort(void);
         Port bindPort(void);

--- a/include/rtosc/ports.h
+++ b/include/rtosc/ports.h
@@ -97,7 +97,7 @@ struct RtData
  */
 struct Port {
     const char  *name;    //!< Pattern for messages to match
-    const char  *metadata;//!< Statically accessable data about port
+    const char  *metadata;//!< Statically accessible data about port
     const Ports *ports;   //!< Pointer to further ports
     std::function<void(msg_t, RtData&)> cb;//!< Callback for matching functions
 
@@ -391,7 +391,7 @@ void path_search(const rtosc::Ports& root, const char *str, const char *needle,
  *   port args must be of types
  *   * "s" (location under @p root to look up port, or empty-string to search
  *          directly at @p root)
- *   * "s" (only port names starting with this sting are returned, use
+ *   * "s" (only port names starting with this string are returned, use
  *          empty-string or nullptr to match everything)
  * @param max_ports Maximum number (or higher) of child ports in any of your
  *     app's ports.

--- a/include/rtosc/pretty-format.h
+++ b/include/rtosc/pretty-format.h
@@ -154,7 +154,7 @@ int rtosc_count_printed_arg_vals_of_msg(const char* msg);
  *   almost all cases (except arrays), n being 1 is sufficient.
  * @param buffer_for_strings A buffer with enough space for scanned
  *   strings and blobs
- * @param bufsize Size of @p buffer_for_strings , will be shrinked to the
+ * @param bufsize Size of @p buffer_for_strings , will be shrunk to the
  *   bufferbytes left after the scan
  * @param args_before Number of arguments scanned before this one
  * @param follow_ellipsis Whether an argument followed by an ellipsis is

--- a/include/rtosc/rtosc-time.h
+++ b/include/rtosc/rtosc-time.h
@@ -66,7 +66,7 @@ rtosc_arg_val_t* rtosc_arg_val_from_params(rtosc_arg_val_t* dest,
 rtosc_arg_val_t* rtosc_arg_val_current_time(rtosc_arg_val_t* dest);
 
 /**
- * @brief       Create a time tag with the "immediatelly" value.
+ * @brief       Create a time tag with the "immediately" value.
  * @note        This is different to the current time, see OSC specs
  * @param dest  Where to store the result
  * @return      The same as dest
@@ -116,7 +116,7 @@ struct tm *rtosc_params_from_arg_val(const rtosc_arg_val_t* arg);
  * @param arg   The arg val
  * @return      The "fractional parts of a second". This integer is in range
  *              [0,2^32), as required in the OSC specs. To convert the result
- *              futher into a float value, see rtosc_secfracs2float.
+ *              further into a float value, see rtosc_secfracs2float.
  */
 uint64_t rtosc_secfracs_from_arg_val(const rtosc_arg_val_t* arg);
 bool rtosc_arg_val_is_immediatelly(const rtosc_arg_val_t* arg);

--- a/include/rtosc/savefile.h
+++ b/include/rtosc/savefile.h
@@ -119,7 +119,7 @@ private:
  *   version structs if needed. All other members shall not be initialized.
  * @return The number of messages read, or, if there was a read error,
  *   or the dispatcher did refuse to dispatch,
- *   the number of bytes read until the read error occured minus one
+ *   the number of bytes read until the read error occurred minus one
  */
 int dispatch_printed_messages(const char* messages,
                               const struct Ports& ports, void* runtime,
@@ -133,7 +133,7 @@ int dispatch_printed_messages(const char* messages,
  * @param appver Version of the application calling this function
  * @param fileStr If given, the new savefile will be appended to
  *   this passed savefile
- * @return The resulting savefile as an std::sting
+ * @return The resulting savefile as an std::string
  */
 std::string save_to_file(const struct Ports& ports, void* runtime,
                          const char* appname, rtosc_version appver,
@@ -151,7 +151,7 @@ std::string save_to_file(const struct Ports& ports, void* runtime,
  * @param appver Version of the application calling this function
  * @param dispatcher Modifier for the messages; NULL if no modifiers are needed
  * @return The number of messages read, or, if there was a read error,
- *   the negated number of bytes read until the read error occured minus one
+ *   the negated number of bytes read until the read error occurred minus one
  */
 int load_from_file(const char* file_content,
                    const struct Ports& ports, void* runtime,

--- a/include/rtosc/thread-link.h
+++ b/include/rtosc/thread-link.h
@@ -34,7 +34,7 @@ namespace rtosc {
 typedef const char *msg_t;
 
 /**
- * ThreadLink - A simple wrapper around jack's ringbuffers desinged to make
+ * ThreadLink - A simple wrapper around jack's ringbuffers designed to make
  * sending messages via rt-osc trivial.
  * This class provides the basics of reading and writing events via fixed sized
  * buffers, which can be specified at compile time.

--- a/src/cpp/default-value.cpp
+++ b/src/cpp/default-value.cpp
@@ -77,7 +77,7 @@ const char* get_default_value(const char* port_name, const Ports& ports,
     }
 
     // If return_value is NULL, this can have two meanings:
-    //   1. there was no depedent annotation
+    //   1. there was no dependent annotation
     //     => check for a direct (non-dependent) default value
     //        (a non existing direct default value is OK)
     //   2. there was a dependent annotation, but the dependent value has no

--- a/src/cpp/midimapper.cpp
+++ b/src/cpp/midimapper.cpp
@@ -586,7 +586,7 @@ const rtosc::Ports MidiMapperRT::ports = {
                 midi.storage = nstorage;}}
 };
 
-//Depricated
+//Deprecated
 Port MidiMapperRT::addWatchPort(void) {
     return Port{"midi-add-watch","",0, [this](msg_t, RtData&) {
         this->addWatch();

--- a/src/cpp/pretty-format.c
+++ b/src/cpp/pretty-format.c
@@ -170,7 +170,7 @@ static int rtosc_print_range(const rtosc_arg_val_t* arg,
                 if(((   rtosc_arg_vals_eq_single(arg+1,   &one, NULL)
                     || rtosc_arg_vals_eq_single(arg+1, &m_one, NULL))
                    && !confusing_prev_arg)
-                   || !rtosc_arg_rep_num(val)) // inifite => special, weird case
+                   || !rtosc_arg_rep_num(val)) // infinite => special, weird case
                 {
                     // for -1 and +1, no second number is needed
                     // however, this only works if
@@ -766,7 +766,7 @@ static const char* try_fmt(const char* src, int exp, const char* fmt,
 static const char* scanf_fmtstr(const char* src, char* type)
 {
     const char* end = src;
-    // skip to string end, word end or a closing paranthesis
+    // skip to string end, word end or a closing parenthesis
     for(; *end && !isspace(*end) && (*end != ')') && (*end != ']')
                && strncmp(end, "...", 3); ++end);
 
@@ -1735,7 +1735,7 @@ size_t rtosc_scan_arg_val(const char* src,
 
                 uint64_t secfracs;
 
-                // lossless format is appended in parantheses?
+                // lossless format is appended in parentheses?
                 //  => take it directly from there
                 if(skip_fmt(&src, "%*f (%n"))
                 {
@@ -1775,7 +1775,7 @@ size_t rtosc_scan_arg_val(const char* src,
 
                     const char *fmtstr = scanf_fmtstr_scan(src, bytes16,
                                                            &type);
-                    if(!arg->type) // the first occurence determins the type
+                    if(!arg->type) // the first occurrence determines the type
                      arg->type = type;
 
                     switch(type)
@@ -1799,7 +1799,7 @@ size_t rtosc_scan_arg_val(const char* src,
                     }
                     else
                     {
-                        // is a lossless part appended in parantheses?
+                        // is a lossless part appended in parentheses?
                         const char* after_num = src;
                         skip_while(&after_num, isspace);
                         if(*after_num == '(') {
@@ -1847,7 +1847,7 @@ size_t rtosc_scan_arg_val(const char* src,
         rtosc_arg_val_t* llhsarg = (args_before > 2 &&
                                     arg[-3].type == '-' &&
                                     rtosc_av_rep_has_delta(arg-3))
-                      // -2 is a delta arg (followin a range arg)?
+                      // -2 is a delta arg (following a range arg)?
                       ? rtosc_arg_val_range_arg(arg-3, rtosc_av_rep_num(arg-3)-1,
                                                 &tmp)
                       : (args_before > 1 && arg[-2].type == '-')

--- a/src/rtosc-time.c
+++ b/src/rtosc-time.c
@@ -74,7 +74,7 @@ uint64_t rtosc_float2secfracs(float secfracsf)
 
     /*
        Remember that
-       (1) shifting a comma over one hex digits mulitplies/divides by 4
+       (1) shifting a comma over one hex digits multiplies/divides by 4
        (2) that secfracsf was scanned as "%a"
        (3) 0x00000001 counts as one secfrac and 0x100000000 would equal 1,
            which means one secfrac is 2^-32

--- a/test/arg-val-cmp.cpp
+++ b/test/arg-val-cmp.cpp
@@ -375,7 +375,7 @@ void multiple_args()
     l[2].val.s = "1";
     r[2].val.s = "0"; //different values
 
-    cmp_gt(l, r, 3, 3, NULL, "multiple args 1", "mutliple args 2", __LINE__);
+    cmp_gt(l, r, 3, 3, NULL, "multiple args 1", "multiple args 2", __LINE__);
 
     l[0].type = r[0].type = 't';
     l[0].val.t = r[0].val.t = 1;

--- a/test/empty-strings.c
+++ b/test/empty-strings.c
@@ -3,7 +3,7 @@
 
 char buffer[1024];
 
-//verify that empty strings can be retreived
+//verify that empty strings can be retrieved
 int main()
 {
     size_t length = rtosc_message(buffer, 1024, "/path", "sss", "", "", "");

--- a/test/liblo.c
+++ b/test/liblo.c
@@ -36,7 +36,7 @@ void speed_liblo_write(void)
 
     double seconds = (t_off - t_on) * 1.0 / CLOCKS_PER_SEC;
     printf("Liblo Write Performance: %f seconds for the test\n", seconds);
-    printf("Liblo Write Performace:  %f ns per message\n", seconds*1e9/repeats);
+    printf("Liblo Write Performance:  %f ns per message\n", seconds*1e9/repeats);
 }
 
 void speed_liblo_read(void)
@@ -63,7 +63,7 @@ void speed_liblo_read(void)
 
     double seconds = (t_off - t_on) * 1.0 / CLOCKS_PER_SEC;
     printf("Liblo Read Performance: %f seconds for the test\n", seconds);
-    printf("Liblo Read Performace:  %f ns per message\n", seconds*1e9/repeats);
+    printf("Liblo Read Performance:  %f ns per message\n", seconds*1e9/repeats);
 }
 
 void speed_rtosc_write(void)
@@ -80,7 +80,7 @@ void speed_rtosc_write(void)
 
     double seconds = (t_off - t_on) * 1.0 / CLOCKS_PER_SEC;
     printf("RTOSC Write Performance: %f seconds for the test\n", seconds);
-    printf("RTOSC Write Performace:  %f ns per message\n", seconds*1e9/repeats);
+    printf("RTOSC Write Performance:  %f ns per message\n", seconds*1e9/repeats);
 }
 
 void speed_rtosc_read(void)
@@ -102,7 +102,7 @@ void speed_rtosc_read(void)
 
     double seconds = (t_off - t_on) * 1.0 / CLOCKS_PER_SEC;
     printf("RTOSC Read Performance: %f seconds for the test\n", seconds);
-    printf("RTOSC Read Performace:  %f ns per message\n", seconds*1e9/repeats);
+    printf("RTOSC Read Performance:  %f ns per message\n", seconds*1e9/repeats);
 }
 
 int result_var = 0;

--- a/test/nested-bundles.c
+++ b/test/nested-bundles.c
@@ -80,11 +80,11 @@ int main()
     assert_int_eq(3, rtosc_bundle_elements(buffer_d, len),
             "Verify Bundle 2's Subelements", __LINE__);
     assert_str_eq("bundle", rtosc_argument(rtosc_bundle_fetch(rtosc_bundle_fetch(buffer_d, 1), 1), 0).s,
-            "Verify Nested Message's Integrety", __LINE__);
+            "Verify Nested Message's Integrity", __LINE__);
 
     //Verify the failure behavior when a bad length is provided
     assert_int_eq(2, rtosc_bundle_elements(buffer_d, len-1),
-            "Verify Aparent Bundles With Truncated Length", __LINE__);
+            "Verify Apparent Bundles With Truncated Length", __LINE__);
     assert_int_eq(0, rtosc_message_length(buffer_d, len-1),
             "Verify Bad Message Is Detected With Truncation", __LINE__);
 

--- a/test/path-collapse.cpp
+++ b/test/path-collapse.cpp
@@ -1,7 +1,7 @@
 #include "rtosc/ports.h"
 #include "common.h"
 
-//Workaround for cygwin compliation where -std=c++11
+//Workaround for cygwin compilation where -std=c++11
 //results in strdup() not getting exposed by string.h
 static char *dupstr(const char *in)
 {

--- a/test/performance.cpp
+++ b/test/performance.cpp
@@ -126,7 +126,7 @@ void print_results(const char* libname,
     assert(ns_per_dispatch < 100000.00); // fit the field width
 
     printf("%s Performance: %8.2f seconds for the test\n", libname, seconds);
-    printf("%s Performace:  %8.2f ns per dispatch\n", libname, ns_per_dispatch);
+    printf("%s Performance:  %8.2f ns per dispatch\n", libname, ns_per_dispatch);
 }
 
 int main()

--- a/test/pretty-format.cpp
+++ b/test/pretty-format.cpp
@@ -101,7 +101,7 @@ void scan_and_print_single()
     check("immediately", NULL, "the timestamp \"immediately\"", __LINE__);
     check_alt("now", NULL, "the timestamp \"now\"", __LINE__, "immediately");
 
-    // must be printed lossless, but second fractions are zero => no parantheses
+    // must be printed lossless, but second fractions are zero => no parentheses
     check_alt("2016-11-16 00:00:00.123 (...+0x0p-32s)", NULL,
               "a timestamp with exact second fractions", __LINE__,
               "2016-11-16");
@@ -372,7 +372,7 @@ void ranges()
     check("[true false ... ]", NULL, "alternating true-false-range", __LINE__);
     assert('-' == scanned[2].type);
     assert_int_eq(0, rtosc_av_rep_num(scanned+2),
-                  "true-false range is inifinite", __LINE__);
+                  "true-false range is infinite", __LINE__);
     assert_int_eq(1, rtosc_av_rep_has_delta(scanned+2),
                   "true-false range has delta", __LINE__);
 }
@@ -557,7 +557,7 @@ void scan_invalid()
     BAD(".e3"); // numbers missing
 #if 0
     // reading strtod(3p) these don't look legal,
-    // but "unfortunatelly" they work
+    // but "unfortunately" they work
     BAD("0x1p+"); // exponent missing
     BAD("1.0e"); // exponent missing
 #endif
@@ -566,7 +566,7 @@ void scan_invalid()
     fail_at_arg("1.0 -0x1.8p+0)", 3, __LINE__); // read as 2 ints + ')'
     BAD("1.0 (x1.8p+0)");
     BAD("1.0 (-0x1.8p+0");
-    BAD("(-0x0p-32)"); // parantheses not allowed
+    BAD("(-0x0p-32)"); // parentheses not allowed
 
     /*
         chars
@@ -649,7 +649,7 @@ void scan_invalid()
 
     BAD("2x");
 
-    // infite ranges
+    // infinite ranges
     BAD("1 ..."); // not allowed outside of bundle
 
     /*

--- a/test/simple-messages.c
+++ b/test/simple-messages.c
@@ -35,7 +35,7 @@ int main()
             "Build A Simple With-Allocation Message", __LINE__);
 
     printf("#Suite 3: misc regression tests\n");
-    //Verify that a string argument can be retreived
+    //Verify that a string argument can be retrieved
     rtosc_message(buffer, 256, "/register", "iis", 2, 13, "/amp-env/av");
     assert_str_eq("/amp-env/av",rtosc_argument(buffer,2).s,
             "Verify Basic String Can Be Read", __LINE__);
@@ -59,7 +59,7 @@ int main()
     float f = 13523.34;
     sz = rtosc_message(buffer, 32, "oscil/freq", "f", f);
     assert_true(sz != 0, "Build Simple Float Message", __LINE__);
-    assert_flt_eq(f, rtosc_argument(buffer,0).f, "Check Float Retreival", __LINE__);
+    assert_flt_eq(f, rtosc_argument(buffer,0).f, "Check Float Retrieval", __LINE__);
 
 
     //Simple Char Ret
@@ -72,11 +72,11 @@ int main()
     assert_int_eq(0xef, rtosc_argument(buffer, 3).i,
             "Check Last Char Argument", __LINE__);
 
-    //Verify argument retreval for short messages
+    //Verify argument retrieval for short messages
     sz = rtosc_message(buffer, 256, "/b", "c", 7);
     assert_int_eq(12, sz, "Build Min-Length Allocated Arg Message", __LINE__);
     assert_int_eq(7, rtosc_argument(buffer+1, 0).i,
-            "Verify Arg Retreival", __LINE__);
+            "Verify Arg Retrieval", __LINE__);
 
     //Work on a recently found bug
     printf("#Check packed blobs\n");

--- a/test/thread-link-test.cpp
+++ b/test/thread-link-test.cpp
@@ -25,7 +25,7 @@ void test_contiguous_write()
     // does not corrupt the "message under test"
     thread_link.write(portname, "i", 42);
 
-    // 10 rounds are enough to have 1 discontigous write
+    // 10 rounds are enough to have 1 discontiguous write
     for (int round = 0; round < 10; ++round)
     {
         // write 17 bytes + 3 bytes padding + 4 bytes argstr + 4 bytes args = 28 bytes

--- a/test/undo-test.cpp
+++ b/test/undo-test.cpp
@@ -83,7 +83,7 @@ int main()
 
     ports.dispatch(message_buff, rt);
     assert_int_eq(1, rt.matches,
-            "Verify A Single Leaf Dispatch Has Occured", __LINE__);
+            "Verify A Single Leaf Dispatch Has Occurred", __LINE__);
     assert_int_eq(7, o.b, "Verify State Change Has Been Applied", __LINE__);
 
     rt.enable = false;


### PR DESCRIPTION
Fixed a variety of typos ranging from msc. source comments, documentation, and source.