### PR TITLE
Fixup: Re-add `-fPIC`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,8 @@ target_compile_features(rtosc-cpp PUBLIC cxx_std_11)
 target_include_directories(rtosc  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_compile_options(rtosc      PRIVATE
         "$<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-std=c99>")
+set_target_properties(rtosc PROPERTIES POSITION_INDEPENDENT_CODE ON)
+set_target_properties(rtosc-cpp PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 if(RTOSC_IWYU_PATH AND RTOSC_INCLUDE_WHAT_YOU_USE)
     set(RTOSC_IWYU_PATH_AND_OPTIONS


### PR DESCRIPTION
Fixup of c00fdb161004e06e52ef46ba921014bd15b1601b

The mentioned commit removes the `-fPIC` flag, but this is needed in Zyn: Even though zyn links rtosc as a `.a` file, the plugin versions are shared objects and do require that every part, including rtosc is compiled with `-fPIC`.

On the other side it is desired to compile rtosc as a `.a` into zyn to be able to use link time optimization (LTO) and for distributional reasons.