### PR TITLE
Fix CMake builds only building static libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,11 +95,11 @@ endif(MSVC)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/cpp/version.c.in
     ${CMAKE_CURRENT_BINARY_DIR}/cpp/version.c)
 
-add_library(rtosc SHARED STATIC
+add_library(rtosc
     src/rtosc.c
     src/dispatch.c
     src/rtosc-time.c)
-add_library(rtosc-cpp SHARED STATIC
+add_library(rtosc-cpp
     ${CMAKE_CURRENT_BINARY_DIR}/cpp/version.c
     src/cpp/ports.cpp src/cpp/ports-runtime.cpp
     src/cpp/default-value.cpp src/cpp/savefile.cpp src/cpp/port-checker.cpp


### PR DESCRIPTION
Fixes cmake builds with `-DBUILD_SHARED_LIBS=ON`. They were only generating static libraries.

Specifying STATIC or SHARED isn't the way to do it; it's up to the build config:
- `-DBUILD_SHARED_LIBS=ON` = only generate shared (.so) libraries
- `-DBUILD_SHARED_LIBS=OFF` = only generate static (.a) libraries