### PR TITLE
Adjust tests for liblo-0.32

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -18,12 +18,10 @@ jobs:
                     -B build
                     -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake
                     -DRTOSC_WERROR=1
-                    -DCMAKE_BUILD_TYPE=Debug
+                    -DCMAKE_BUILD_TYPE=Release
                     ",
-            build: "cmake --build build --config Debug",
-            # all tests work except "performance" (liblo bug?)
-            # this weird regex lets all those tests run, except performance
-            test: "ctest --output-on-failure --test-dir build -R '(i|s|t|g)'"
+            build: "cmake --build build --config Release",
+            test: "ctest --output-on-failure --test-dir build"
           }
           - {
             name: "Ubuntu gcc",

--- a/test/performance.cpp
+++ b/test/performance.cpp
@@ -42,11 +42,11 @@ int liblo_count(const char *path, const char *types,
 }
 #endif
 
-#define dummy(x)  {#x, NULL, NULL, do_nothing}
-#define dummyT(x) {#x"::T:F", NULL, NULL, do_nothing}
-#define dummyC(x) {#x"::c", NULL, NULL, do_nothing}
-#define dummyI(x) {#x"::i", NULL, NULL, do_nothing}
-#define dummyO(x) {#x"::s:c:i", NULL, NULL, do_nothing}
+#define dummy(x)  {"/"#x, NULL, NULL, do_nothing}
+#define dummyT(x) {"/"#x"::T:F", NULL, NULL, do_nothing}
+#define dummyC(x) {"/"#x"::c", NULL, NULL, do_nothing}
+#define dummyI(x) {"/"#x"::i", NULL, NULL, do_nothing}
+#define dummyO(x) {"/"#x"::s:c:i", NULL, NULL, do_nothing}
 
 
 //TODO Consider performance penalty of argument specifier
@@ -134,26 +134,26 @@ int main()
     /*
      * create all the messages
      */
-    rtosc_message(events[0],  1024, "PFMDetune", "i", 23);
-    rtosc_message(events[1],  1024, "oscil/blam", "c", 23);
-    rtosc_message(events[2],  1024, "PFilterEnabled", "T");
-    rtosc_message(events[3],  1024, "PVolume", "c", 23);
-    rtosc_message(events[4],  1024, "Enabled", "T");
-    rtosc_message(events[5],  1024, "Unison_size", "c", 1);
-    rtosc_message(events[6],  1024, "Unison_frequency_spread", "c", 2);
-    rtosc_message(events[7],  1024, "Unison_stereo_spread", "c", 3);
-    rtosc_message(events[8],  1024, "Unison_vibratto", "c", 4);
-    rtosc_message(events[9],  1024, "Unison_vibratto_speed", "c", 5);
-    rtosc_message(events[10], 1024, "Unison_invert_phase", "");
-    rtosc_message(events[11], 1024, "FilterLfo/another/few/layers", "");
-    rtosc_message(events[12], 1024, "FreqEnvelope/blam", "");
-    rtosc_message(events[13], 1024, "PINVALID_RANDOM_STRING", "ics", 23, 23, "23");
-    rtosc_message(events[14], 1024, "PFMVelocityScaleFunction", "i", 23);
-    rtosc_message(events[15], 1024, "PFMDetune", "i", 230);
-    rtosc_message(events[16], 1024, "Pfixedfreq", "F");
-    rtosc_message(events[17], 1024, "detunevalue", "");
-    rtosc_message(events[18], 1024, "PfixedfreqET", "c", 10);
-    rtosc_message(events[19], 1024, "PfixedfreqET", "");
+    rtosc_message(events[0],  1024, "/PFMDetune", "i", 23);
+    rtosc_message(events[1],  1024, "/oscil/blam", "c", 23);
+    rtosc_message(events[2],  1024, "/PFilterEnabled", "T");
+    rtosc_message(events[3],  1024, "/PVolume", "c", 23);
+    rtosc_message(events[4],  1024, "/Enabled", "T");
+    rtosc_message(events[5],  1024, "/Unison_size", "c", 1);
+    rtosc_message(events[6],  1024, "/Unison_frequency_spread", "c", 2);
+    rtosc_message(events[7],  1024, "/Unison_stereo_spread", "c", 3);
+    rtosc_message(events[8],  1024, "/Unison_vibratto", "c", 4);
+    rtosc_message(events[9],  1024, "/Unison_vibratto_speed", "c", 5);
+    rtosc_message(events[10], 1024, "/Unison_invert_phase", "");
+    rtosc_message(events[11], 1024, "/FilterLfo/another/few/layers", "");
+    rtosc_message(events[12], 1024, "/FreqEnvelope/blam", "");
+    rtosc_message(events[13], 1024, "/PINVALID_RANDOM_STRING", "ics", 23, 23, "23");
+    rtosc_message(events[14], 1024, "/PFMVelocityScaleFunction", "i", 23);
+    rtosc_message(events[15], 1024, "/PFMDetune", "i", 230);
+    rtosc_message(events[16], 1024, "/Pfixedfreq", "F");
+    rtosc_message(events[17], 1024, "/detunevalue", "");
+    rtosc_message(events[18], 1024, "/PfixedfreqET", "c", 10);
+    rtosc_message(events[19], 1024, "/PfixedfreqET", "");
     RtData d;
     d.loc_size = 1024;
     d.obj = d.loc = loc_buffer;


### PR DESCRIPTION
This adjusts the `performance` test due to liblo's commit

4899a0d9653a347ee25cf5013ebddc615b1ef80f

The rtosc code was requested to stay as it is - i.e. to still allow messages not starting with `/`.

Also, this changes Windows build to take Release, which gets around the (still existing) liblo issue where the Debug execution of `performance` hits the assertion

```
Assertion `d.matches == 3600000' failed.
```

(which causes infinite test execution on Windows due to failed assert). Using Windows `Release` build allows us to run the `performance` test with liblo 0.32.