### PR TITLE
Fix invalid 0 initialization

### DIFF
--- a/src/rtosc.c
+++ b/src/rtosc.c
@@ -435,7 +435,7 @@ size_t rtosc_amessage(char              *buffer,
 
 static rtosc_arg_t extract_arg(const uint8_t *arg_pos, char type)
 {
-    rtosc_arg_t result = {0};
+    rtosc_arg_t result = {};
     //trivial case
     if(!has_reserved(type)) {
         switch(type)


### PR DESCRIPTION
The line

```c++
rtosc_arg_t result = {0};
```

fails to zero-initialize the whole union (it only does so for the first member, which is different behavior to structs).

This is fixed using "designated zero-initialization":

```c++
rtosc_arg_t result = {};
```

Checked the whole code, no other such union initialization issues.

This fixes test failures on some machines:

  fat-message
  test-arg-iter
  SaveOscPresets
  SaveOscBigFile