### PR TITLE
Use cast in unsafe comparison

### DIFF
--- a/include/rtosc/port-sugar.h
+++ b/include/rtosc/port-sugar.h
@@ -485,9 +485,9 @@ template<class T> constexpr T spice(T*t) {return *t;}
         if(!strcmp("", args)) {\
             data.reply(loc, obj->name ? "T" : "F"); \
         } else { \
-            if(obj->name != rtosc_argument(msg, 0).T) { \
+            if(obj->name != (bool)rtosc_argument(msg, 0).T) { \
                 data.broadcast(loc, args);\
-                obj->name = rtosc_argument(msg, 0).T; \
+                obj->name = (bool)rtosc_argument(msg, 0).T; \
                 rChangeCb; \
             } \
         } rBOIL_END
@@ -554,11 +554,11 @@ template<class T> constexpr T spice(T*t) {return *t;}
         if(!strcmp("", args)) {\
             data.reply(loc, obj->name[idx] ? "T" : "F"); \
         } else { \
-            if(obj->name[idx] != rtosc_argument(msg, 0).T) { \
+            if(obj->name[idx] != (bool)rtosc_argument(msg, 0).T) { \
                 data.broadcast(loc, args);\
                 rChangeCb; \
             } \
-            obj->name[idx] = rtosc_argument(msg, 0).T; \
+            obj->name[idx] = (bool)rtosc_argument(msg, 0).T; \
         } rBOILS_END
 
 #define rArrayTCbMember(name, member) rBOILS_BEGIN \


### PR DESCRIPTION
**Please review, but do not merge yet**

This was used to fix some MSVC compiler warnings in zyn.

The zyn submodule should not yet be updated past this commit until zyn has changed its respective `unsigned char` class members to `bool`.